### PR TITLE
User notified of poll end on voting page

### DIFF
--- a/client/src/hooks/index.ts
+++ b/client/src/hooks/index.ts
@@ -6,3 +6,4 @@ export * from "./useErrorDuration";
 export * from "./useInitializeSocket";
 export * from "./useSetToken";
 export * from "./useWaitForVoting";
+export * from "./useWaitForResults";

--- a/client/src/hooks/useWaitForResults.ts
+++ b/client/src/hooks/useWaitForResults.ts
@@ -1,0 +1,25 @@
+import { useEffect } from "react";
+import { useAppSelector, useAppDispatch } from ".";
+import { selectPayloadFromToken } from "../app/slices/authSlice";
+import { selectPoll } from "../app/slices/pollSlice";
+import { setError } from "../app/slices/errorSlice";
+import { isJwtPayload } from "../utils";
+
+export function useWaitForResults() {
+    const poll = useAppSelector(selectPoll);
+    const usersHaveRanked = Object.keys(poll?.rankings || {});
+    const payload = useAppSelector(selectPayloadFromToken);
+
+    const dispatch = useAppDispatch();
+    
+    useEffect(() => {
+        if(poll?.results && Array.from(poll?.results).length > 0 && isJwtPayload(payload) && !usersHaveRanked.includes(payload.id)) {
+            dispatch(setError("Admin has ended voting"));
+            const timeout = setTimeout(() => {
+                location.reload()
+            }, 3000);
+    
+            return () => clearTimeout(timeout);
+        }
+    });
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -11,7 +11,7 @@
     text-align: center;
     background: gold;
     color: black;
-    line-height: 1.95;
+    line-height: 2;
   }
 }
 

--- a/client/src/pages/VotingPage.tsx
+++ b/client/src/pages/VotingPage.tsx
@@ -1,5 +1,5 @@
-import { Page} from "react-onsenui";
-import { useAppSelector, useAppDispatch } from "../hooks";
+import { Page } from "react-onsenui";
+import { useAppSelector, useAppDispatch, useWaitForResults } from "../hooks";
 import { selectIsAdmin, selectPoll } from "../app/slices/pollSlice";
 import { useState } from "react"
 import { Button, RankedNomination, ConfirmationDialog } from "../components";
@@ -7,6 +7,9 @@ import { emitSocketEvent } from "../app/socketActions";
 import { Route, resultsRoute } from "../utils";
 
 export default function VotingPage({navigator}: Route["props"]){
+
+    useWaitForResults();
+
     const [rankings, setRankings] = useState<string[]>([]);
     const [showConfirmVotes, setShowConfirmVotes] = useState(false);
     const [showConfirmCancel, setShowConfirmCancel] = useState(false);


### PR DESCRIPTION
User now receives a notification if the admin ends the poll before the user has submitted their rankings and redirects them to the results page.